### PR TITLE
fix: scale total height with graphHeight

### DIFF
--- a/dist/index.js
+++ b/dist/index.js
@@ -56,6 +56,11 @@ function FPSStats(_ref) {
       graphHeight = _ref$graphHeight === void 0 ? 29 : _ref$graphHeight,
       _ref$graphWidth = _ref.graphWidth,
       graphWidth = _ref$graphWidth === void 0 ? 70 : _ref$graphWidth;
+  var padding = 3;
+  var textLineHeight = 10;
+  var extraGap = 1;
+  var numericGraphHeight = Number(graphHeight);
+  var totalHeight = Number.isFinite(numericGraphHeight) ? numericGraphHeight + padding * 2 + textLineHeight + extraGap : 46;
 
   var _useReducer = (0, _react.useReducer)(function (state) {
     var currentTime = Date.now();
@@ -105,13 +110,13 @@ function FPSStats(_ref) {
     style: {
       zIndex: 999999,
       position: 'fixed',
-      height: 46,
+      height: totalHeight,
       width: graphWidth + 6,
-      padding: 3,
+      padding: padding,
       backgroundColor: '#000',
       color: '#00ffff',
       fontSize: '9px',
-      lineHeight: '10px',
+      lineHeight: "".concat(textLineHeight, "px"),
       fontFamily: 'Helvetica, Arial, sans-serif',
       fontWeight: 'bold',
       boxSizing: 'border-box',
@@ -124,9 +129,9 @@ function FPSStats(_ref) {
   }, /*#__PURE__*/_react["default"].createElement("span", null, fps[len - 1], " FPS"), /*#__PURE__*/_react["default"].createElement("div", {
     style: {
       position: 'absolute',
-      left: 3,
-      right: 3,
-      bottom: 3,
+      left: padding,
+      right: padding,
+      bottom: padding,
       height: graphHeight,
       background: '#282844',
       boxSizing: 'border-box'

--- a/src/index.js
+++ b/src/index.js
@@ -9,6 +9,13 @@ function FPSStats ({
   graphHeight = 29,
   graphWidth = 70
 }) {
+  const padding = 3
+  const textLineHeight = 10
+  const extraGap = 1
+  const numericGraphHeight = Number(graphHeight)
+  const totalHeight = Number.isFinite(numericGraphHeight)
+    ? numericGraphHeight + padding * 2 + textLineHeight + extraGap
+    : 46
   const [state, dispatch] = useReducer(
     state => {
       const currentTime = Date.now()
@@ -60,13 +67,13 @@ function FPSStats ({
       style={{
         zIndex: 999999,
         position: 'fixed',
-        height: 46,
+        height: totalHeight,
         width: graphWidth + 6,
-        padding: 3,
+        padding,
         backgroundColor: '#000',
         color: '#00ffff',
         fontSize: '9px',
-        lineHeight: '10px',
+        lineHeight: `${textLineHeight}px`,
         fontFamily: 'Helvetica, Arial, sans-serif',
         fontWeight: 'bold',
         boxSizing: 'border-box',
@@ -81,9 +88,9 @@ function FPSStats ({
       <div
         style={{
           position: 'absolute',
-          left: 3,
-          right: 3,
-          bottom: 3,
+          left: padding,
+          right: padding,
+          bottom: padding,
           height: graphHeight,
           background: '#282844',
           boxSizing: 'border-box'


### PR DESCRIPTION
fixes: https://github.com/smplrspace/react-fps-stats/issues/27

This change makes the outer container height derive from graphHeight, so taller graphs don’t outgrow the container. The total container height is computed as graphHeight + padding*2 + lineHeight + extraGap. 

The extraGap = 1 is derived from the old fixed height. Previously: container height: 46, with padding: 3 top/bottom (6 total), lineHeight: 10, and default GraphHeight: 29. `46 − (29 + 6 + 10) = 1`. So it matches the previous layout exactly.

Behavior for non‑numeric graphHeight remains unchanged (falls back to the original height).

Manual check: increased graphHeight above default; FPS label no longer gets covered.

`graphHeight: 160`
before this change: 
![2026-02-08 at 17 37](https://github.com/user-attachments/assets/49752956-cedc-40ef-bea0-8061ef3b4187)

after this change:
![2026-02-08 at 17 20](https://github.com/user-attachments/assets/78dc8a4b-b136-492d-98c8-81f0c943d08b)
